### PR TITLE
mod. volume command for RX-V477; removed safeguard

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ Node.js module for controlling Yamaha RX-V-series receiver (HTTP API)
 - c get system configuration
 - p set power (on/off)
 - m set mute (on/off)
-- v set volume (min 200, max X)
+- v set volume (in 0.5 dB steps from –80.5 dB to 16.5 dB (very loud!), written as `-805` to `165`)
 - i set input (HDMIx, AVx, AUDI, TUNER ...)
 
 ```

--- a/main.js
+++ b/main.js
@@ -30,13 +30,8 @@ yamaha.isOnline().then(function(isOnline){
         yamaha.setPower(params);
         break;
       case 'v':
-        if (!Number.isInteger(params)){
-          console.log("Parameter is not a number: " + params);
-          break;
-        }
-
         console.log("Volume to: " + params);
-        yamaha.setVolume(params);
+        yamaha.setVolume(parseInt(params));
         break;
       case 'i':
           console.log("Set intput to: " + params);

--- a/yamaha.js
+++ b/yamaha.js
@@ -74,11 +74,6 @@ Yamaha.prototype.getVolume = function(){
 };
 
 Yamaha.prototype.setVolume = function(volume){
-
-  // Safety: Do not set volume ever too loud
-  if (volume < 200)
-    volume = 200;
-
   var xml = this.commands.setVolumeCommand(volume);
   return deferredAction(this.getUrl(), xml, function(result){
     return result.YAMAHA_AV.Main_Zone[0].Volume[0].Lvl[0].Val[0];

--- a/yamahaCommands.js
+++ b/yamahaCommands.js
@@ -59,7 +59,7 @@ YamahaCommands.prototype.getVolumeCommand = function(){
 
 YamahaCommands.prototype.setVolumeCommand = function(volume){
   var cmd = 'PUT';
-  var volPayload = this.setVolumeValue.format({val : volume, exp : '1', unit :'db'});
+  var volPayload = this.setVolumeValue.format({val : volume, exp : '1', unit : 'dB'});
   var request = this.volumeLevel.format({value : volPayload});
 
   var pload = this.mainZoneWrapper.format({request_text : request});


### PR DESCRIPTION
Volume range: [-805, 165] in steps of 5, see README for details.

(Note: Be careful, the upper end is extremely loud; safe-guards have
been removed!)
