### PR TITLE
Add SSDP Discovery

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,24 +9,31 @@ Node.js module for controlling Yamaha RX-V-series receiver (HTTP API)
 
 #### Command line arguments
 
-* 1st argument ip-address
-* 2nd argument command
-* 3rd argument parameters
+```
+node main.js [IP_ADDRESS] COMMAND PARAMETERS
+```
 
-- s get status
-- c get system configuration
-- p set power (on/off)
-- m set mute (on/off)
-- v set volume (in 0.5 dB steps from –80.5 dB to 16.5 dB (very loud!), written as `-805` to `165`)
-- i set input (HDMIx, AVx, AUDI, TUNER ...)
+If `IP_ADDRESS` is omitted, the receiver's IP will be automatically discovered
+via SSDP. Discovery can take up to 3 seconds.
+
+`COMMAND` can be one of the following:
+
+* s get status
+* c get system configuration
+* p set power (on/off)
+* m set mute (on/off)
+* v set volume (in 0.5 dB steps from –80.5 dB to 16.5 dB (very loud!), written as `-805` to `165`)
+* i set input (HDMIx, AVx, AUDI, TUNER ...)
+
+Examples:
 
 ```
-node main.js 192.168.1.40 p on
-node main.js 192.168.1.40 p off
-node main.js 192.168.1.40 m on
-node main.js 192.168.1.40 m off
-node main.js 192.168.1.40 v -550
-node main.js 192.168.1.40 s
-node main.js 192.168.1.40 c
-node main.js 192.168.1.40 i HDMI1
+node main.js s
+node main.js c
+node main.js p on
+node main.js p off
+node main.js m on
+node main.js m off
+node main.js v -550
+node main.js i HDMI1
 ```

--- a/main.js
+++ b/main.js
@@ -4,47 +4,57 @@ var ip = process.argv[2];
 var cmd = process.argv[3];
 var params = process.argv[4];
 
-console.log("Connecting to: " + ip);
+if (ip.length == 1){
+  ip = null;
+  cmd = process.argv[2];
+  params = process.argv[3];
+}
 
 var yamaha = new Yamaha(ip);
 
-yamaha.isOnline().then(function(isOnline){
-  if (isOnline === false){
-    console.log("Device returned unknown response");
-  }
-  else{
-    switch(cmd)
-    {
-      case 's':
-        GetState();
-        break;
-      case 'c':
-        GetSystemConfig();
-        break;
-      case 'm':
-        console.log("Mute to: " + params);
-        yamaha.setMute(params);
-        break;
-      case 'p':
-        console.log("Power to: " + params);
-        yamaha.setPower(params);
-        break;
-      case 'v':
-        console.log("Volume to: " + params);
-        yamaha.setVolume(parseInt(params));
-        break;
-      case 'i':
-          console.log("Set intput to: " + params);
-          yamaha.setInput(params);
-          break;
-      default:
-        console.log("Unknown command");
-        break;
+yamaha.discover()
+  .then(function(ip){
+    console.log("Connecting to: " + ip);
+    return yamaha.isOnline();
+  })
+  .then(function(isOnline){
+    if (isOnline === false){
+      console.log("Device returned unknown response");
     }
-  }
-}, function(error){
-  console.log("Amplifier not online");
-});
+    else{
+      switch(cmd)
+      {
+        case 's':
+          GetState();
+          break;
+        case 'c':
+          GetSystemConfig();
+          break;
+        case 'm':
+          console.log("Mute to: " + params);
+          yamaha.setMute(params);
+          break;
+        case 'p':
+          console.log("Power to: " + params);
+          yamaha.setPower(params);
+          break;
+        case 'v':
+          console.log("Volume to: " + params);
+          yamaha.setVolume(parseInt(params));
+          break;
+        case 'i':
+            console.log("Set intput to: " + params);
+            yamaha.setInput(params);
+            break;
+        default:
+          console.log("Unknown command");
+          break;
+      }
+    }
+  })
+  .catch(function(error){
+    console.log("Amplifier not online");
+  });
 
 function GetState(){
   yamaha.isOn().then(function(result){

--- a/package.json
+++ b/package.json
@@ -7,7 +7,8 @@
     "string-format": "0.2.1",
     "request": "2.47.0",
     "q": "1.0.1",
-    "xml2js": "0.4.4"
+    "xml2js": "0.4.4",
+    "node-ssdp": "2.8.0"
   },
   "devDependencies": {
   	"jshint": "^2.5.1",

--- a/test/yamahaCommands_test.js
+++ b/test/yamahaCommands_test.js
@@ -36,7 +36,7 @@ describe('Yamaha XML Commands', function(){
     });
 
     it('should return set volume', function(){
-      var cmd = '<YAMAHA_AV cmd="PUT"><Main_Zone><Volume><Lvl><Val>210</Val><Exp>1</Exp><Unit>db</Unit></Lvl></Volume></Main_Zone></YAMAHA_AV>';
+      var cmd = '<YAMAHA_AV cmd="PUT"><Main_Zone><Volume><Lvl><Val>210</Val><Exp>1</Exp><Unit>dB</Unit></Lvl></Volume></Main_Zone></YAMAHA_AV>';
       assert.equal(cmd, yamaha.setVolumeCommand(210));
     });
   });

--- a/test/yamahaDiscovery_test.js
+++ b/test/yamahaDiscovery_test.js
@@ -1,0 +1,29 @@
+var assert = require("assert");
+var YamahaDiscovery = require('../yamahaDiscovery.js');
+
+describe('Yamaha Discovery', function(){
+
+  var ip = "10.0.0.2";
+  var yamaha = new YamahaDiscovery(ip);
+
+  describe('getIp()', function(){
+    it('should return '+ip, function(){
+      yamaha.getIp()
+        .then(function(result){
+          assert.equal(ip, result);
+        })
+        .done();
+    });
+  });
+
+  describe('getUrl()', function(){
+    it('should return http://'+ip+'/YamahaRemoteControl/ctrl', function(){
+      yamaha.getUrl()
+        .then(function(result){
+          assert.equal('http://'+ip+'/YamahaRemoteControl/ctrl', result);
+        })
+        .done();
+    });
+  });
+
+});

--- a/test/yamaha_test.js
+++ b/test/yamaha_test.js
@@ -20,11 +20,4 @@ describe('Yamaha Receiver', function(){
   });
 */
 
-  describe('Get Url', function(){
-    it('should return http://'+ip+'/YamahaRemoteControl/ctrl', function(){
-      assert.equal('http://'+ip+'/YamahaRemoteControl/ctrl', yamaha.getUrl());
-    });
-  });
-
-
 });

--- a/yamahaDiscovery.js
+++ b/yamahaDiscovery.js
@@ -1,0 +1,85 @@
+var SsdpClient = require('node-ssdp').Client;
+var Q = require('q');
+var Request = require('request');
+var parseString = require('xml2js').parseString;
+
+function YamahaDiscovery(ip){
+  this.ssdpClient = new SsdpClient();
+  this.st = 'urn:schemas-upnp-org:device:MediaRenderer:1';
+  this.url = 'http://{ip}/YamahaRemoteControl/ctrl';
+
+  this.ip = ip;
+}
+
+YamahaDiscovery.prototype.getUrl = function(){
+  var deferred = Q.defer();
+
+  var self = this;
+  this.getIp().then(function (ip){
+    deferred.resolve(self.url.format({ip : ip}));
+  }, function(error){
+    deferred.reject(error);
+  });
+
+  return deferred.promise;
+};
+
+YamahaDiscovery.prototype.getIp = function(){
+  var deferred = Q.defer();
+
+  if (this.ip){
+    deferred.resolve(this.ip);
+  }
+  else{
+    var self = this;
+    this.ssdpClient.on('response', function (headers, statusCode, rinfo){
+      if (statusCode == 200) {
+        getDescription(headers.LOCATION, function (){
+          if (self.timer){
+            clearTimeout(self.timer);
+            self.timer = null;
+          }
+          self.ssdpClient.stop();
+
+          self.ip = rinfo.address;
+          deferred.resolve(rinfo.address);
+        });
+      }
+    });
+
+    this.ssdpClient.search(this.st);
+
+    this.timer = setTimeout(function(){
+      deferred.reject("Discovery timeout");
+      self.ssdpClient.stop();
+    }, 3000);
+  }
+
+  return deferred.promise;
+};
+
+function getDescription(loc, successAction){
+  var request = Request.get({
+    method: 'GET',
+    uri: loc
+  },
+  function (error, response, body) {
+    if (!error && response.statusCode == 200) {
+      validateDescription(body, successAction);
+    }
+  });
+}
+
+function validateDescription(body, successAction){
+  parseString(body, function(err, result){
+    if (!err){
+      var manufacturer = result.root.device[0].manufacturer[0];
+      var modelDescription = result.root.device[0].modelDescription[0];
+      if (manufacturer.match(/yamaha/i) && modelDescription.match(/AV/)){
+        successAction();
+      }
+    }
+  });
+}
+
+module.exports = YamahaDiscovery;


### PR DESCRIPTION
This change makes the IP address optional. It is omitted, the receiver's IP will be automatically discovered via [SSDP](https://en.wikipedia.org/wiki/Simple_Service_Discovery_Protocol). Discovery can take up to 3 seconds.

Additionally, I fixed an existing unit test that should have been checking for `dB`.
